### PR TITLE
Fixes to issues with PF5 upgrade

### DIFF
--- a/frontend/packages/console-app/src/components/network-policies/_create-network-policy.scss
+++ b/frontend/packages/console-app/src/components/network-policies/_create-network-policy.scss
@@ -16,7 +16,7 @@
 .co-create-networkpolicy__expandable-xl
   > .pf-v5-c-form__field-group-header
   .pf-v5-c-form__field-group-header-title-text {
-  font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+  font-family: var(--pf-v5-global--FontFamily--heading);
   font-size: var(--pf-v5-global--FontSize--xl);
   font-weight: var(--pf-v5-global--FontWeight--normal);
   line-height: var(--pf-v5-global--LineHeight--md);

--- a/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
+++ b/frontend/packages/console-shared/src/components/quick-search/QuickSearchList.scss
@@ -44,7 +44,7 @@
   &__item-name {
     font-size: var(--pf-v5-global--FontSize--md);
     font-weight: 400;
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
   }
   &__all-items {
     border-bottom: var(--pf-v5-c-data-list__item--sm--BorderBottomWidth) solid

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -182,6 +182,7 @@ const App = (props) => {
           <Page
             // Need to pass mainTabIndex=null to enable keyboard scrolling as default tabIndex is set to -1 by patternfly
             mainTabIndex={null}
+            className="pf-c-page" // legacy pf-c-page class needed for PF4 component styling
             header={
               <Masthead
                 isNavOpen={isNavOpen}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -65,7 +65,7 @@
         theme = 'dark';
       }
       if (theme === 'dark') {
-        document.documentElement.classList.add('pf-v5-theme-dark');
+        document.documentElement.classList.add('pf-v5-theme-dark', 'pf-theme-dark'); // legacy pf-theme-dark class needed for PF4 component styling
       }
     </script>
   </head>

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -82,7 +82,7 @@ form.pf-v5-c-form {
   top: -999em;
 }
 
-// PatternFly 4 overrides
+// PatternFly overrides
 
 .pf-v5-c-about-modal-box {
   --pf-v5-c-about-modal-box__brand-image--Height: auto !important; // allow logo to be taller
@@ -95,14 +95,30 @@ form.pf-v5-c-form {
 
 // Webpack will not properly bundle the background-image from PatternFly
 @media only screen and (min-width: 576px) {
-  .pf-v5-c-about-modal-box__hero {
+  .pf-v5-c-about-modal-box {
     background-image: url('../imgs/pfbg_992.jpg') !important;
+    background-position: 400px !important;
+    background-size: cover !important;
   }
+}
+
+.pf-v5-c-about-modal-box__brand {
+  background-color: var(--pf-v5-global--palette--black-1000);
 }
 
 .pf-v5-c-about-modal-box__brand-image,
 .pf-v5-c-brand {
   max-width: 100%;
+}
+
+.pf-v5-c-about-modal-box__content {
+  background-color: var(--pf-v5-global--palette--black-1000);
+  padding: var(--pf-v5-global--spacer--2xl) var(--pf-v5-global--spacer--3xl);
+  
+  --pf-v5-c-about-modal-box__content--MarginBottom: 0;
+  --pf-v5-c-about-modal-box__content--MarginLeft: 0;
+  --pf-v5-c-about-modal-box__content--MarginRight: 0;
+  --pf-v5-c-about-modal-box__content--MarginTop: 0;
 }
 
 .pf-v5-c-alert--top-margin {
@@ -199,10 +215,15 @@ form.pf-v5-c-form {
 .modal-dialog {
   .pf-v5-c-app-launcher,
   .pf-v5-c-button,
+  .pf-c-button,
   .pf-v5-c-dropdown,
+  .pf-c-dropdown,
   .pf-v5-c-dropdown__menu-item,
+  .pf-c-dropdown__menu-item,
   .pf-v5-c-dropdown__toggle,
-  .pf-v5-c-form-control {
+  .pf-c-dropdown__toggle,
+  .pf-v5-c-form-control,
+  .pf-c-form-control {
     font-size: $font-size-base;
     height: auto;
   }

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -19,8 +19,11 @@ $pf-v5-global--font-path: '~@patternfly/patternfly/assets/fonts';
 $table-border-color: var(--pf-v5-global--BorderColor--300);
 
 :root {
-  --pf-v5-global--FontSize--md: 14px; // Numerical value required, same as $font-size-base
+  // Numerical value required
+  --pf-v5-global--FontSize--md: 14px; // same as $font-size-base
+  --pf-global--FontSize--md: 14px; // same as $font-size-base
   --pf-v5-global--FontSize--sm: 13px;
+  --pf-global--FontSize--sm: 13px;
 }
 
 // == Declare max breakpoints from PatternFly variables

--- a/frontend/public/style/ancillary/_patternfly4.scss
+++ b/frontend/public/style/ancillary/_patternfly4.scss
@@ -1,4 +1,4 @@
-// Addition of specific styles to bring elements into visual likeness with PF4
+// Addition of specific styles to bring elements into visual likeness with PF
 // These are either components we don't currently use or that our current
 // markup structure doesn't align with PF4 so we must apply through targeted css
 
@@ -12,17 +12,16 @@
 :where(:not([class*="pf-v5-c-"])) {
   @at-root h1#{&} {
     font-size: var(--pf-v5-global--FontSize--2xl);
-    line-height: var(--pf-v5-global--LineHeight--sm);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
     word-break: break-word;
   }
-
+  
   @at-root h2#{&} {
     font-size: var(--pf-v5-global--FontSize--xl);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
@@ -31,7 +30,7 @@
 
   @at-root h3#{&} {
     font-size: var(--pf-v5-global--FontSize--lg);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
@@ -40,7 +39,7 @@
 
   @at-root h4#{&} {
     font-size: var(--pf-v5-global--FontSize--md);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
@@ -49,7 +48,7 @@
 
   @at-root h5#{&} {
     font-size: var(--pf-v5-global--FontSize--md);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
@@ -58,7 +57,7 @@
 
   @at-root h6#{&} {
     font-size: var(--pf-v5-global--FontSize--md);
-    font-family: var(--pf-v5-global--FontFamily--heading--sans-serif);
+    font-family: var(--pf-v5-global--FontFamily--heading);
     font-weight: var(--pf-v5-global--FontWeight--normal);
     line-height: var(--pf-v5-global--LineHeight--md);
     margin-bottom: var(--pf-v5-global--spacer--sm);
@@ -71,10 +70,10 @@
   select,
   textarea,
   .pf-v5-c-badge {
-    font-family: var(--pf-v5-global--FontFamily--sans-text);
+    font-family: var(--pf-v5-global--FontFamily--text);
   }
 
   @at-root button#{&} {
-    font-family: var(--pf-v5-global--FontFamily--sans-text);
+    font-family: var(--pf-v5-global--FontFamily--text);
   }
 }


### PR DESCRIPTION
- Assign headings to font-family `RedHatDisplay`
- Include `pf-theme-dark` so PF4 components receive correct styling in dark mode
- Include `pf-c-page` className on `Page` component so PF4 components receive correct styling
- Reassign about modal background image since `pf-v5-c-about-modal-box__hero` no longer exists and adjust content so that it's presentation matches current display
- Include `--pf-global--FontSize--md` `--pf-global--FontSize--sm` in our `_vars` for our custom default font sizes
