### PR TITLE
Disable global reset for PF4 entry

### DIFF
--- a/frontend/public/vendor-patternfly-4-shared.scss
+++ b/frontend/public/vendor-patternfly-4-shared.scss
@@ -1,5 +1,4 @@
-// Config
-@import 'style/vars';
+$pf-global--enable-reset: false;
 
 // PatternFly 4 stylesheets. We need these to support existing Console dynamic plugins
 // that may use PatternFly 4 shared modules as their runtime dependencies.


### PR DESCRIPTION
Followup to https://github.com/jpuzz0/console/pull/15
Noticed that there was an additional reset of globals when the PF4 css was loaded.
This led to some unintended visual changes.
Can disable for the PF4 entry since we're already doing a global reset.
