### PR TITLE
Sweep through and update old <table> elements with pf-v5 classes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,8 @@
       "^.+\\.(gql|graphql)$": "jest-transform-graphql"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime)/.*)"    ],
+      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime)/.*)"
+    ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/.*/integration-tests-cypress"
@@ -145,7 +146,7 @@
     "@patternfly/react-tokens": "5.1.0",
     "@patternfly/react-topology": "5.0.0",
     "@patternfly/react-user-feedback": "5.0.0",
-    "@patternfly/react-virtualized-extension": "5.0.0",
+    "@patternfly/react-virtualized-extension": "5.1.0",
     "@patternfly-4/patternfly": "npm:@patternfly/patternfly@4.224.5",
     "@patternfly-4/quickstarts": "npm:@patternfly/quickstarts@2.4.2",
     "@patternfly-4/react-catalog-view-extension": "npm:@patternfly/react-catalog-view-extension@4.96.1",

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsConditions.tsx
@@ -15,30 +15,30 @@ const NodeDetailsConditions: React.FC<NodeDetailsConditionsProps> = ({ node }) =
     <div className="co-m-pane__body">
       <SectionHeading text={t('console-app~Node conditions')} />
       <div className="co-table-container">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>{t('console-app~Type')}</th>
-              <th>{t('console-app~Status')}</th>
-              <th>{t('console-app~Reason')}</th>
-              <th>{t('console-app~Updated')}</th>
-              <th>{t('console-app~Changed')}</th>
+        <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+          <thead className="pf-v5-c-table__thead">
+            <tr className="pf-v5-c-table__tr">
+              <th className="pf-v5-c-table__th">{t('console-app~Type')}</th>
+              <th className="pf-v5-c-table__th">{t('console-app~Status')}</th>
+              <th className="pf-v5-c-table__th">{t('console-app~Reason')}</th>
+              <th className="pf-v5-c-table__th">{t('console-app~Updated')}</th>
+              <th className="pf-v5-c-table__th">{t('console-app~Changed')}</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody className="pf-v5-c-table__tbody">
             {_.map(node.status.conditions, (c, i) => (
-              <tr key={i}>
-                <td>
+              <tr className="pf-v5-c-table__tr" key={i}>
+                <td className="pf-v5-c-table__td">
                   <CamelCaseWrap value={c.type} />
                 </td>
-                <td>{c.status || '-'}</td>
-                <td>
+                <td className="pf-v5-c-table__td">{c.status || '-'}</td>
+                <td className="pf-v5-c-table__td">
                   <CamelCaseWrap value={c.reason} />
                 </td>
-                <td>
+                <td className="pf-v5-c-table__td">
                   <Timestamp timestamp={c.lastHeartbeatTime} />
                 </td>
-                <td>
+                <td className="pf-v5-c-table__td">
                   <Timestamp timestamp={c.lastTransitionTime} />
                 </td>
               </tr>

--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsImages.tsx
@@ -15,26 +15,24 @@ const NodeDetailsImages: React.FC<NodeDetailsImagesProps> = ({ node }) => {
     <div className="co-m-pane__body">
       <SectionHeading text={t('console-app~Images')} />
       <div className="co-table-container">
-        <table className="table table--layout-fixed">
-          <colgroup>
-            <col className="col-sm-10 col-xs-9" />
-            <col className="col-sm-2 col-xs-3" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>{t('console-app~Name')}</th>
-              <th>{t('console-app~Size')}</th>
+        <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+          <thead className="pf-v5-c-table__thead">
+            <tr className="pf-v5-c-table__tr">
+              <th className="pf-v5-c-table__th">{t('console-app~Name')}</th>
+              <th className="pf-v5-c-table__th">{t('console-app~Size')}</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody className="pf-v5-c-table__tbody">
             {_.map(images, (image, i) => (
-              <tr key={i}>
-                <td className="co-break-all co-select-to-copy">
+              <tr className="pf-v5-c-table__tr" key={i}>
+                <td className="pf-v5-c-table__td pf-m-break-word co-select-to-copy">
                   {image.names.find(
                     (name: string) => !name.includes('@') && !name.includes('<none>'),
                   ) || image.names[0]}
                 </td>
-                <td>{units.humanize(image.sizeBytes, 'binaryBytes', true).string || '-'}</td>
+                <td className="pf-v5-c-table__td">
+                  {units.humanize(image.sizeBytes, 'binaryBytes', true).string || '-'}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -57,19 +57,19 @@ import { requireOperatorGroup } from './operator-group';
 import { InstallPlanReview, referenceForStepResource } from './index';
 
 const tableColumnClasses = [
-  '',
-  '',
-  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-v5-u-w-16-on-lg'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
+  'pf-v5-c-table__td',
+  'pf-v5-c-table__td',
+  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-v5-u-w-16-on-lg', 'pf-v5-c-table__td'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg', 'pf-v5-c-table__td'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-xl', 'pf-v5-c-table__td'),
   Kebab.columnClass,
 ];
 
 const componentsTableColumnClasses = [
-  '',
-  '',
-  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-v5-u-w-16-on-lg'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
+  'pf-v5-c-table__td',
+  'pf-v5-c-table__td',
+  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-v5-u-w-16-on-lg', 'pf-v5-c-table__td'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg', 'pf-v5-c-table__td'),
 ];
 
 export const InstallPlanTableRow: React.FC<RowFunctionArgs> = ({ obj }) => {
@@ -460,18 +460,21 @@ export const InstallPlanPreview: React.FC<InstallPlanPreviewProps> = ({
         <div key={steps[0].resolving} className="co-m-pane__body">
           <SectionHeading text={steps[0].resolving} />
           <div className="co-table-container">
-            <table className="pf-v5-c-table pf-m-compact pf-m-border-rows">
-              <thead>
-                <tr>
+            <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+              <thead className="pf-v5-c-table__thead">
+                <tr className="pf-v5-c-table__tr">
                   <th className={componentsTableColumnClasses[0]}>{t('olm~Name')}</th>
                   <th className={componentsTableColumnClasses[1]}>{t('olm~Kind')}</th>
                   <th className={componentsTableColumnClasses[2]}>{t('olm~Status')}</th>
                   <th className={componentsTableColumnClasses[3]}>{t('olm~API version')}</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="pf-v5-c-table__tbody">
                 {steps.map((step) => (
-                  <tr key={`${referenceForStepResource(step.resource)}-${step.resource.name}`}>
+                  <tr
+                    key={`${referenceForStepResource(step.resource)}-${step.resource.name}`}
+                    className="pf-v5-c-table__tr"
+                  >
                     <td className={componentsTableColumnClasses[0]}>
                       {['Present', 'Created'].includes(step.status) ? (
                         <ResourceLink

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -569,26 +569,29 @@ const OperandsTable: React.FC<OperandsTableProps> = ({ operands, loaded, csvName
       data={operands}
       loaded={loaded}
     >
-      <table className="pf-v5-c-table pf-m-compact pf-m-border-rows">
-        <thead>
-          <tr key="operand-table-header-row">
-            <th className="pf-m-width-35">{t('olm~Name')}</th>
-            <th>{t('olm~Kind')}</th>
-            <th>{t('olm~Namespace')}</th>
+      <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+        <thead className="pf-v5-c-table__thead">
+          <tr className="pf-v5-c-table__tr" key="operand-table-header-row">
+            <th className="pf-m-width-35 pf-v5-c-table__th">{t('olm~Name')}</th>
+            <th className="pf-v5-c-table__th">{t('olm~Kind')}</th>
+            <th className="pf-v5-c-table__th">{t('olm~Namespace')}</th>
           </tr>
         </thead>
         <tbody>
           {operands
             .sort((a, b) => a.metadata.name.localeCompare(b.metadata.name))
             .map((operand) => (
-              <tr key={operand.metadata.uid}>
-                <td>
+              <tr className="pf-v5-c-table__tr" key={operand.metadata.uid}>
+                <td className="pf-v5-c-table__td">
                   <OperandLink obj={operand} csvName={csvName} onClick={cancel} />
                 </td>
-                <td className="co-break-word" data-test-operand-kind={operand.kind}>
+                <td
+                  className="pf-v5-c-table__td pf-m-break-word"
+                  data-test-operand-kind={operand.kind}
+                >
                   {operand.kind}
                 </td>
-                <td>
+                <td className="pf-v5-c-table__td">
                   {operand.metadata.namespace ? (
                     <ResourceLink
                       kind="Namespace"

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -6,7 +6,7 @@
   }
 
   .pf-v5-c-app-launcher__menu-item-external-icon {
-    --pf-v5-c-app-launcher__menu-item-external-icon--Color: var(--pf-v5-global--icon--Color--light);
+    --pf-v5-c-app-launcher__menu-item-external-icon--Color: var(--pf-v5-c-menu__item-action--Color);
 
     opacity: 1;
   }

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -711,8 +711,7 @@ const AppContents: React.FC<{}> = () => {
       </PageSection>
       <div id="content-scrollable">
         <PageSection
-          variant={PageSectionVariants.light}
-          className="pf-v5-page__main-section--flex"
+          className="pf-v5-page__main-section--flex co-page-backdrop"
           padding={{ default: 'noPadding' }}
         >
           <ErrorBoundaryPage>

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -204,18 +204,18 @@ const OperandVersions: React.FC<OperandVersionsProps> = ({ versions }) => {
     <EmptyBox label={t('public~versions')} />
   ) : (
     <div className="co-table-container">
-      <table className="table">
-        <thead>
-          <tr>
-            <th>{t('public~Name')}</th>
-            <th>{t('public~Version')}</th>
+      <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+        <thead className="pf-v5-c-table__thead">
+          <tr className="pf-v5-c-table__tr">
+            <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Version')}</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="pf-v5-c-table__tbody">
           {_.map(versions, ({ name, version }, i) => (
-            <tr key={i}>
-              <td>{name}</td>
-              <td>{version}</td>
+            <tr className="pf-v5-c-table__tr" key={i}>
+              <td className="pf-v5-c-table__td">{name}</td>
+              <td className="pf-v5-c-table__td">{version}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1259,32 +1259,36 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
               </Text>
             </TextContent>
             <div className="co-table-container">
-              <table className="table">
-                <thead>
-                  <tr>
-                    <th>{t('public~Version')}</th>
-                    <th>{t('public~State')}</th>
-                    <th>{t('public~Started')}</th>
-                    <th>{t('public~Completed')}</th>
+              <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+                <thead className="pf-v5-c-table__thead">
+                  <tr className="pf-v5-c-table__tr">
+                    <th className="pf-v5-c-table__th">{t('public~Version')}</th>
+                    <th className="pf-v5-c-table__th">{t('public~State')}</th>
+                    <th className="pf-v5-c-table__th">{t('public~Started')}</th>
+                    <th className="pf-v5-c-table__th">{t('public~Completed')}</th>
                     {releaseNotes && (
-                      <th className="hidden-xs hidden-sm">{t('public~Release notes')}</th>
+                      <th className="pf-v5-c-table__th pf-m-hidden pf-m-visible-on-md">
+                        {t('public~Release notes')}
+                      </th>
                     )}
                   </tr>
                 </thead>
-                <tbody>
+                <tbody className="pf-v5-c-table__tbody">
                   {_.map(history, (update, i) => (
-                    <tr key={i}>
+                    <tr className="pf-v5-c-table__tr" key={i}>
                       <td
-                        className="co-break-all co-select-to-copy"
+                        className="pf-v5-c-table__td pf-m-break-word co-select-to-copy"
                         data-test-id="cv-details-table-version"
                       >
                         {update.version || '-'}
                       </td>
-                      <td data-test-id="cv-details-table-state">{update.state || '-'}</td>
-                      <td>
+                      <td className="pf-v5-c-table__td" data-test-id="cv-details-table-state">
+                        {update.state || '-'}
+                      </td>
+                      <td className="pf-v5-c-table__td">
                         <Timestamp timestamp={update.startedTime} />
                       </td>
-                      <td>
+                      <td className="pf-v5-c-table__td">
                         {update.completionTime ? (
                           <Timestamp timestamp={update.completionTime} />
                         ) : (
@@ -1292,7 +1296,7 @@ export const ClusterVersionDetailsTable: React.FC<ClusterVersionDetailsTableProp
                         )}
                       </td>
                       {releaseNotes && (
-                        <td className="hidden-xs hidden-sm">
+                        <td className="pf-v5-c-table__td pf-m-hidden pf-m-visible-on-md">
                           {getReleaseNotesLink(update.version) ? (
                             <ReleaseNotesLink version={update.version} />
                           ) : (

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -41,20 +41,26 @@ const IdentityProviders: React.FC<IdentityProvidersProps> = ({ identityProviders
     <EmptyBox label={t('public~Identity providers')} />
   ) : (
     <div className="co-table-container">
-      <table className="table">
-        <thead>
-          <tr>
-            <th>{t('public~Name')}</th>
-            <th>{t('public~Type')}</th>
-            <th>{t('public~Mapping method')}</th>
+      <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+        <thead className="pf-v5-c-table__thead">
+          <tr className="pf-v5-c-table__th">
+            <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Type')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Mapping method')}</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="pf-v5-c-table__tbody">
           {_.map(identityProviders, (idp) => (
-            <tr key={idp.name}>
-              <td data-test-idp-name={idp.name}>{idp.name}</td>
-              <td data-test-idp-type-for={idp.name}>{idp.type}</td>
-              <td data-test-idp-mapping-for={idp.name}>{idp.mappingMethod || 'claim'}</td>
+            <tr className="pf-v5-c-table__th" key={idp.name}>
+              <td className="pf-v5-c-table__td" data-test-idp-name={idp.name}>
+                {idp.name}
+              </td>
+              <td className="pf-v5-c-table__td" data-test-idp-type-for={idp.name}>
+                {idp.type}
+              </td>
+              <td className="pf-v5-c-table__td" data-test-idp-mapping-for={idp.name}>
+                {idp.mappingMethod || 'claim'}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/public/components/container.tsx
+++ b/frontend/public/components/container.tsx
@@ -113,18 +113,18 @@ const Ports: React.FC<PortsProps> = ({ ports }) => {
   }
 
   return (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>{t('public~Name')}</th>
-          <th>{t('public~Container')}</th>
+    <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+      <thead className="pf-v5-c-table__thead">
+        <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Container')}</th>
         </tr>
       </thead>
       <tbody>
         {ports.map((p: ContainerPort, i: number) => (
-          <tr key={i}>
-            <td>{p.name || '-'}</td>
-            <td>{p.containerPort}</td>
+          <tr className="pf-v5-c-table__tr" key={i}>
+            <td className="pf-v5-c-table__td">{p.name || '-'}</td>
+            <td className="pf-v5-c-table__td">{p.containerPort}</td>
           </tr>
         ))}
       </tbody>
@@ -145,20 +145,22 @@ const VolumeMounts: React.FC<VolumeMountProps> = ({ volumeMounts }) => {
   }
 
   return (
-    <table className="table table--layout-fixed">
-      <thead>
-        <tr>
-          <th>{t('public~Access')}</th>
-          <th>{t('public~Location')}</th>
-          <th>{t('public~Mount path')}</th>
+    <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+      <thead className="pf-v5-c-table__thead">
+        <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Access')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Location')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Mount path')}</th>
         </tr>
       </thead>
       <tbody>
         {volumeMounts.map((v: VolumeMount) => (
-          <tr key={v.name}>
-            <td>{v.readOnly === true ? t('public~Read only') : t('public~Read/write')}</td>
-            <td className="co-break-all co-select-to-copy">{v.name}</td>
-            <td>
+          <tr className="pf-v5-c-table__tr" key={v.name}>
+            <td className="pf-v5-c-table__td">
+              {v.readOnly === true ? t('public~Read only') : t('public~Read/write')}
+            </td>
+            <td className="pf-v5-c-table__td pf-m-break-word co-select-to-copy">{v.name}</td>
+            <td className="pf-v5-c-table__td">
               {v.mountPath ? (
                 <div className="co-break-all co-select-to-copy">{v.mountPath}</div>
               ) : (
@@ -200,18 +202,18 @@ const Env: React.FC<EnvProps> = ({ env }) => {
   };
 
   return (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>{t('public~Name')}</th>
-          <th>{t('public~Value')}</th>
+    <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+      <thead className="pf-v5-c-table__thead">
+        <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Value')}</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody className="pf-v5-c-table__tbody">
         {env.map((e: EnvVar, i: number) => (
-          <tr key={i}>
-            <td>{e.name}</td>
-            <td>{value(e)}</td>
+          <tr className="pf-v5-c-table__tr" key={i}>
+            <td className="pf-v5-c-table__td">{e.name}</td>
+            <td className="pf-v5-c-table__td">{value(e)}</td>
           </tr>
         ))}
       </tbody>

--- a/frontend/public/components/factory/Table/VirtualizedTable.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTable.tsx
@@ -5,6 +5,7 @@ import {
   Table as PfTable,
   TableHeader as TableHeaderDeprecated,
 } from '@patternfly/react-table/deprecated';
+import * as classNames from 'classnames';
 import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
 import { VirtualizedTableFC, TableColumn, TableDataProps } from '@console/dynamic-plugin-sdk';
 
@@ -52,7 +53,7 @@ const isColumnVisible = <D extends any>(
 
 export const TableData: React.FC<TableDataProps> = ({ className, id, activeColumnIDs, children }) =>
   (activeColumnIDs.has(id) || id === '') && (
-    <td id={id} className={className} role="gridcell">
+    <td id={id} className={classNames('pf-v5-c-table__td', className)} role="gridcell">
       {children}
     </td>
   );

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -136,7 +136,7 @@ export const TableRow: React.FC<TableRowProps> = ({
       data-test-rows="resource-row"
       data-key={trKey}
       style={style}
-      className={className}
+      className={classNames('pf-v5-c-table__tr', className)}
       role="row"
     />
   );
@@ -206,7 +206,7 @@ export const TableData: React.FC<TableDataProps> = ({
   ...props
 }) => {
   return isColumnVisible(window.innerWidth, columnID, columns, showNamespaceOverride) ? (
-    <td {...props} className={className} role="gridcell" />
+    <td {...props} className={classNames('pf-v5-c-table__td', className)} role="gridcell" />
   ) : null;
 };
 TableData.displayName = 'TableData';

--- a/frontend/public/components/group.tsx
+++ b/frontend/public/components/group.tsx
@@ -129,20 +129,20 @@ const UsersTable: React.FC<UsersTableProps> = ({ group, users }) => {
   return _.isEmpty(users) ? (
     <EmptyBox label={t('public~Users')} />
   ) : (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>{t('public~Name')}</th>
-          <th />
+    <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+      <thead className="pf-v5-c-table__thead">
+        <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+          <th className="pf-v5-c-table__th" />
         </tr>
       </thead>
-      <tbody>
+      <tbody className="pf-v5-c-table__tbody">
         {users.map((user: string) => (
-          <tr key={user}>
-            <td>
+          <tr className="pf-v5-c-table__tr" key={user}>
+            <td className="pf-v5-c-table__td">
               <ResourceLink kind={referenceForModel(UserModel)} name={user} />
             </td>
-            <td className="dropdown-kebab-pf pf-v5-c-table__action">
+            <td className="pf-v5-c-table__td dropdown-kebab-pf pf-v5-c-table__action">
               <UserKebab group={group} user={user} />
             </td>
           </tr>

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -186,18 +186,18 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
           <span className="text-muted">{t('public~No labels')}</span>
         ) : (
           <div className="co-table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>{t('public~Name')}</th>
-                  <th>{t('public~Value')}</th>
+            <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+              <thead className="pf-v5-c-table__thead">
+                <tr className="pf-v5-c-table__tr">
+                  <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+                  <th className="pf-v5-c-table__th">{t('public~Value')}</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="pf-v5-c-table__tbody">
                 {_.map(sortedLabels, ({ name, value }) => (
-                  <tr key={name}>
-                    <td>{name}</td>
-                    <td>{value}</td>
+                  <tr className="pf-v5-c-table__tr" key={name}>
+                    <td className="pf-v5-c-table__td">{name}</td>
+                    <td className="pf-v5-c-table__td">{value}</td>
                   </tr>
                 ))}
               </tbody>
@@ -211,20 +211,20 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
           <span className="text-muted">{t('public~No environment variables')}</span>
         ) : (
           <div className="co-table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>{t('public~Name')}</th>
-                  <th>{t('public~Value')}</th>
+            <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+              <thead className="pf-v5-c-table__thead">
+                <tr className="pf-v5-c-table__tr">
+                  <th className="pf-v5-c-table__th">{t('public~Name')}</th>
+                  <th className="pf-v5-c-table__th">{t('public~Value')}</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="pf-v5-c-table__tbody">
                 {_.map(config.Env, (nameValueStr, i) => {
                   const pair = splitEnv(nameValueStr);
                   return (
-                    <tr key={i}>
-                      <td>{pair.name}</td>
-                      <td>{pair.value}</td>
+                    <tr className="pf-v5-c-table__tr" key={i}>
+                      <td className="pf-v5-c-table__td">{pair.name}</td>
+                      <td className="pf-v5-c-table__td">{pair.value}</td>
                     </tr>
                   );
                 })}

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -96,14 +96,14 @@ export const LimitRangeDetailsRow: React.SFC<LimitRangeDetailsRowProps> = ({
   limit,
 }) => {
   return (
-    <tr className="co-resource-list__item">
-      <td>{limitType}</td>
-      <td>{resource}</td>
-      <td>{limit.min || '-'}</td>
-      <td>{limit.max || '-'}</td>
-      <td>{limit.defaultRequest || '-'}</td>
-      <td>{limit.default || '-'}</td>
-      <td>{limit.maxLimitRequestRatio || '-'}</td>
+    <tr className="pf-v5-c-table__tr">
+      <td className="pf-v5-c-table__td">{limitType}</td>
+      <td className="pf-v5-c-table__td">{resource}</td>
+      <td className="pf-v5-c-table__td">{limit.min || '-'}</td>
+      <td className="pf-v5-c-table__td">{limit.max || '-'}</td>
+      <td className="pf-v5-c-table__td">{limit.defaultRequest || '-'}</td>
+      <td className="pf-v5-c-table__td">{limit.default || '-'}</td>
+      <td className="pf-v5-c-table__td">{limit.maxLimitRequestRatio || '-'}</td>
     </tr>
   );
 };
@@ -134,26 +134,24 @@ export const LimitRangeDetailsList = (resource) => {
   return (
     <div className="co-m-pane__body">
       <SectionHeading text={t('public~Limits')} />
-      <div className="table-responsive">
-        <table className="co-m-table-grid co-m-table-grid--bordered table">
-          <thead className="co-m-table-grid__head">
-            <tr>
-              <td>{t('public~Type')}</td>
-              <td>{t('public~Resource')}</td>
-              <td>{t('public~Min')}</td>
-              <td>{t('public~Max')}</td>
-              <td>{t('public~Default request')}</td>
-              <td>{t('public~Default limit')}</td>
-              <td>{t('public~Max limit/request ratio')}</td>
-            </tr>
-          </thead>
-          <tbody className="co-m-table-grid__body">
-            {_.map(resource.resource.spec.limits, (limit, index) => (
-              <LimitRangeDetailsRows limit={limit} key={index} />
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+        <thead className="pf-v5-c-table__thead">
+          <tr className="pf-v5-c-table__tr">
+            <th className="pf-v5-c-table__th">{t('public~Type')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Resource')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Min')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Max')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Default request')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Default limit')}</th>
+            <th className="pf-v5-c-table__th">{t('public~Max limit/request ratio')}</th>
+          </tr>
+        </thead>
+        <tbody className="pf-v5-c-table__tbody">
+          {_.map(resource.resource.spec.limits, (limit, index) => (
+            <LimitRangeDetailsRows limit={limit} key={index} />
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -99,20 +99,20 @@ const UnhealthyConditionsTable: React.FC<{ obj: K8sResourceKind }> = ({ obj }) =
   return _.isEmpty(obj.spec.unhealthyConditions) ? (
     <EmptyBox label={t('public~Unhealthy conditions')} />
   ) : (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>{t('public~Status')}</th>
-          <th>{t('public~Timeout')}</th>
-          <th>{t('public~Type')}</th>
+    <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+      <thead className="pf-v5-c-table__thead">
+        <tr className="pf-v5-c-table__tr">
+          <th className="pf-v5-c-table__th">{t('public~Status')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Timeout')}</th>
+          <th className="pf-v5-c-table__th">{t('public~Type')}</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody className="pf-v5-c-table__tbody">
         {obj.spec.unhealthyConditions.map(({ status, timeout, type }, i: number) => (
-          <tr key={i}>
-            <td>{status}</td>
-            <td>{timeout}</td>
-            <td>{type}</td>
+          <tr className="pf-v5-c-table__tr" key={i}>
+            <td className="pf-v5-c-table__td">{status}</td>
+            <td className="pf-v5-c-table__td">{timeout}</td>
+            <td className="pf-v5-c-table__td">{type}</td>
           </tr>
         ))}
       </tbody>

--- a/frontend/public/components/modals/cluster-more-updates-modal.tsx
+++ b/frontend/public/components/modals/cluster-more-updates-modal.tsx
@@ -40,18 +40,18 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
         {clusterUpgradeableFalseAndNotExternallyManaged && (
           <ClusterNotUpgradeableAlert cv={cv} onCancel={cancel} />
         )}
-        <table className="table">
-          <thead>
-            <tr>
-              <th>{t('public~Version')}</th>
-              {releaseNotes && <th>{t('public~Release notes')}</th>}
+        <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+          <thead className="pf-v5-c-table__thead">
+            <tr className="pf-v5-c-table__tr">
+              <th className="pf-v5-c-table__th">{t('public~Version')}</th>
+              {releaseNotes && <th className="pf-v5-c-table__th">{t('public~Release notes')}</th>}
             </tr>
           </thead>
-          <tbody>
+          <tbody className="pf-v5-c-table__tbody">
             {moreAvailableUpdates.map((update) => {
               return (
-                <tr key={update.version}>
-                  <td>
+                <tr className="pf-v5-c-table__tr" key={update.version}>
+                  <td className="pf-v5-c-table__td">
                     {update.version}
                     {clusterUpgradeableFalseAndNotExternallyManaged &&
                       isMinorVersionNewer(getLastCompletedUpdate(cv), update.version) && (
@@ -59,7 +59,7 @@ export const ClusterMoreUpdatesModal: React.FC<ClusterMoreUpdatesModalProps> = (
                       )}
                   </td>
                   {releaseNotes && (
-                    <td>
+                    <td className="pf-v5-c-table__td">
                       {getReleaseNotesLink(update.version) ? (
                         <ReleaseNotesLink version={update.version} />
                       ) : (

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -311,8 +311,8 @@ const showCustomRouteHelp = (
 };
 
 const RouteTargetRow: React.FC<RouteTargetRowProps> = ({ route, target }) => (
-  <tr>
-    <td>
+  <tr className="pf-v5-c-table__tr">
+    <td className="pf-v5-c-table__td">
       <ResourceLink
         kind={target.kind}
         name={target.name}
@@ -320,8 +320,8 @@ const RouteTargetRow: React.FC<RouteTargetRowProps> = ({ route, target }) => (
         title={target.name}
       />
     </td>
-    <td>{target.weight}</td>
-    <td>{calcTrafficPercentage(target.weight, route)}</td>
+    <td className="pf-v5-c-table__td">{target.weight}</td>
+    <td className="pf-v5-c-table__td">{calcTrafficPercentage(target.weight, route)}</td>
   </tr>
 );
 
@@ -464,15 +464,15 @@ const RouteDetails: React.FC<RoutesDetailsProps> = ({ obj: route }) => {
             {t('public~This route splits traffic across multiple services.')}
           </p>
           <div className="co-table-container">
-            <table className="table">
-              <thead>
-                <tr>
-                  <th>{t('public~Service')}</th>
-                  <th>{t('public~Weight')}</th>
-                  <th>{t('public~Percent')}</th>
+            <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+              <thead className="pf-v5-c-table__thead">
+                <tr className="pf-v5-c-table__tr">
+                  <th className="pf-v5-c-table__th">{t('public~Service')}</th>
+                  <th className="pf-v5-c-table__th">{t('public~Weight')}</th>
+                  <th className="pf-v5-c-table__th">{t('public~Percent')}</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="pf-v5-c-table__tbody">
                 <RouteTargetRow route={route} target={route.spec.to} />
                 {_.map(route.spec.alternateBackends, (alternate, i) => (
                   <RouteTargetRow key={i} route={route} target={alternate} />

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -33,17 +33,17 @@ const getTriggerProperty = (trigger: WebhookTrigger) => trigger.type.toLowerCase
 const getTableColumnClasses = (canGetSecret: boolean) => {
   if (canGetSecret) {
     return [
-      '',
-      'pf-m-hidden pf-m-visible-on-xl pf-v5-u-w-50-on-xl co-break-word',
-      'pf-m-hidden pf-m-visible-on-md',
-      '',
+      'pf-v5-c-table__td',
+      'pf-v5-c-table__td pf-m-hidden pf-m-visible-on-xl pf-v5-u-w-50-on-xl  pf-m-break-word',
+      'pf-v5-c-table__td pf-m-hidden pf-m-visible-on-md',
+      'pf-v5-c-table__td',
     ];
   }
   return [
-    'pf-v5-u-w-16-on-md',
-    'pf-v5-u-w-58-on-xl co-break-word',
-    'pf-m-hidden pf-m-visible-on-md pf-v5-u-w-25-on-md',
-    'pf-m-hidden',
+    'pf-v5-c-table__td pf-v5-u-w-16-on-md',
+    'pf-v5-c-table__td pf-v5-u-w-58-on-xl pf-m-break-word',
+    'pf-v5-c-table__td pf-m-hidden pf-m-visible-on-md pf-v5-u-w-25-on-md',
+    'pf-v5-c-table__td pf-m-hidden',
   ];
 };
 
@@ -194,16 +194,10 @@ export const WebhookTriggers: React.FC<WebhookTriggersProps> = (props) => {
         />
       )}
       <SectionHeading text={t('public~Webhooks')} />
-      <div className="co-table-container">
-        <table className="table table--layout-fixed">
-          <colgroup>
-            <col className={tableColumnClasses[0]} />
-            <col className={tableColumnClasses[1]} />
-            <col className={tableColumnClasses[2]} />
-            <col className={tableColumnClasses[3]} />
-          </colgroup>
-          <thead>
-            <tr>
+      <div className="co-table-container pf-v5-c-scroll-inner-wrapper">
+        <table className="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-border-rows">
+          <thead className="pf-v5-c-table__thead">
+            <tr className="pf-v5-c-table__tr">
               <th className={tableColumnClasses[0]}>{t('public~Type')}</th>
               <th className={tableColumnClasses[1]}>{t('public~Webhook URL')}</th>
               <th className={tableColumnClasses[2]}>{t('public~Secret')}</th>
@@ -216,7 +210,7 @@ export const WebhookTriggers: React.FC<WebhookTriggersProps> = (props) => {
               const secretReference = getSecretReference(trigger);
               const clipboardButton = getClipboardButton(trigger);
               return (
-                <tr key={i}>
+                <tr className="pf-v5-c-table__tr" key={i}>
                   <td className={tableColumnClasses[0]}>{trigger.type}</td>
                   <td className={tableColumnClasses[1]}>{webhookURL || '-'}</td>
                   <td className={tableColumnClasses[2]}>{secretReference}</td>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -527,7 +527,7 @@ dl.co-inline {
     .co-m-table-grid__body .row,
     .co-m-table-grid__head {
       border-bottom: var(--pf-v5-global--BorderWidth--sm) solid
-        var(--pf-v5-global--BorderColor--300);
+        var(--pf-v5-global--BorderColor--100);
     }
   }
   .co-m-table-grid {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -201,6 +201,10 @@ form.pf-v5-c-form {
   &__main.default-overflow {
     z-index: calc(var(--pf-v5-c-page__header--ZIndex) + 50);
   }
+  // Default light background for our content
+  .co-page-backdrop {
+    background-color: var(--pf-global--BackgroundColor--100) !important;
+  }
 
   // Apply to primary content section to prevent yaml editor and topology sections from collapsing
   .pf-v5-page__main-section--flex {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1815,12 +1815,29 @@
     react-dropzone "^14.2.3"
     tslib "^2.5.0"
 
+"@patternfly/react-core@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-5.1.1.tgz#9f0c5578c400e8808c56f160f3dd02801c430d3f"
+  integrity sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==
+  dependencies:
+    "@patternfly/react-icons" "^5.1.1"
+    "@patternfly/react-styles" "^5.1.1"
+    "@patternfly/react-tokens" "^5.1.1"
+    focus-trap "7.5.2"
+    react-dropzone "^14.2.3"
+    tslib "^2.5.0"
+
 "@patternfly/react-icons@^5.0.0", "@patternfly/react-icons@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.1.0.tgz#b0f2b932174ac26d1142b259861f747fb6c0fd4f"
   integrity sha512-mSFAJMrT6QUQ10DifYYGSXOPlFob88lWPZXeOyPdstJ8cJRRRVTMYgoR/VnXsUO/vthwFbViY+sS6+/jL8pl9w==
   dependencies:
     "@patternfly/patternfly" "5.0.2"
+
+"@patternfly/react-icons@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.1.1.tgz#be1249e2f3abdc0e280952f88c3d5deb07fe1dde"
+  integrity sha512-9gCxkWz2xcdi0rtXu2F0L68w4tLIlsgGTACo1ggr4aVng9jRX++o1PlCOqscOd9o0NiFnFD7BLlZUGvJWaYEZg==
 
 "@patternfly/react-log-viewer@5.0.0":
   version "5.0.0"
@@ -1838,6 +1855,11 @@
   integrity sha512-RnVS/v1PZuvnXXmPtJamuAprq1lg6tqw6dbeYbm9KmBNXSuB1Iu5fc6kjzrdoSLKBmf6rzpRmafYm2HRwFcrLw==
   dependencies:
     "@patternfly/patternfly" "5.0.2"
+
+"@patternfly/react-styles@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-5.1.1.tgz#73762306972e520c2eff63a8b5412914c51a2ca8"
+  integrity sha512-swO9X+WixYYDsMVsEJp1V8QUfhEQY91QfFm4phfYP4jc2TQ2opIFYdUIHkc+yrZwBhrgb/pPUUfemyqAoSbZcA==
 
 "@patternfly/react-table@5.1.0":
   version "5.1.0"
@@ -1857,6 +1879,11 @@
   integrity sha512-HRBoS3JMbW8vWqz91oW2NGUdLndC40TXvMnEaORNd/I25czOquxnx/HxVh+/bdSkNqByj6+fiTwH2X3fL2Cajg==
   dependencies:
     "@patternfly/patternfly" "5.0.2"
+
+"@patternfly/react-tokens@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-5.1.1.tgz#098b70b4ed4d05217004395abc7395a46acc9abe"
+  integrity sha512-cHuNkzNA9IY9aDwfjSEkitQoVEvRhOJRKhH0yIRlRByEkbdoV9jJZ9xj20hNShE+bxmNuom+MCTQSkpkN1bV8A==
 
 "@patternfly/react-topology@5.0.0":
   version "5.0.0"
@@ -1889,14 +1916,14 @@
     "@patternfly/react-core" "^5.0.0"
     "@patternfly/react-icons" "^5.0.0"
 
-"@patternfly/react-virtualized-extension@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-5.0.0.tgz#4f52e61c974a66d293a66b56f8cdce359c642585"
-  integrity sha512-1DWr5KbIuQojVKEkyQpYOj310A1zlH82twQoV783vsjaAwfo6GDKd8PBSzthA3z+F8p1Yx2bNjjdun0qABtZTQ==
+"@patternfly/react-virtualized-extension@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-virtualized-extension/-/react-virtualized-extension-5.1.0.tgz#59fde60ee11f118c89826c2d1f453ec8dc7d932b"
+  integrity sha512-qCBi5PeAiR54BqXcLHHG5eX4WMohGmSWgLUgENbV4NFyTOarJRzpErNb6Vx5L9D3w9p6Np17UVVnn0eH1pBKcw==
   dependencies:
-    "@patternfly/react-core" "^5.0.0"
-    "@patternfly/react-icons" "^5.0.0"
-    "@patternfly/react-styles" "^5.0.0"
+    "@patternfly/react-core" "^5.1.1"
+    "@patternfly/react-icons" "^5.1.1"
+    "@patternfly/react-styles" "^5.1.1"
     linear-layout-vector "0.0.1"
     react-virtualized "^9.22.5"
     tslib "^2.5.2"
@@ -8444,6 +8471,13 @@ focus-trap@7.4.3:
   integrity sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==
   dependencies:
     tabbable "^6.1.2"
+
+focus-trap@7.5.2:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.5.2.tgz#e5ee678d10a18651f2591ffb66c949fb098d57cf"
+  integrity sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==
+  dependencies:
+    tabbable "^6.2.0"
 
 focus-trap@^4.0.2:
   version "4.0.2"
@@ -15914,7 +15948,7 @@ tabbable@^5.3.2:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
-tabbable@^6.1.2:
+tabbable@^6.1.2, tabbable@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==


### PR DESCRIPTION
Bump version `@patternfly/react-virtualized-extension` to address virtualized table issues
also has minor fixes
Include `co-page-backdrop` class to apply background that doesn't conflict with pf-v5 `PageSection` variant
PF `ApplicationLauncher` is deprecated so icons weren't getting correct color